### PR TITLE
Add default prod opcache config

### DIFF
--- a/templates/configs/app_opcache.prod.j2
+++ b/templates/configs/app_opcache.prod.j2
@@ -2,4 +2,14 @@
 
 {% set config = item.config|default([]) -%}
 
-{{ macros.config(config) -}}
+{{ macros.config_row(config, 'opcache.validate_timestamps', false) }}
+{{ macros.config_row(config, 'opcache.memory_consumption', 128) }}
+{{ macros.config_row(config, 'opcache.max_accelerated_files', 7963) }}
+{{ macros.config_row(config, 'opcache.max_wasted_percentage', 10) }}
+
+{{ macros.config(config, [
+  'opcache.validate_timestamps',
+  'opcache.memory_consumption',
+  'opcache.max_accelerated_files',
+  'opcache.max_wasted_percentage',
+]) -}}


### PR DESCRIPTION
Based on https://tideways.io/profiler/blog/fine-tune-your-opcache-configuration-to-avoid-caching-suprises and http://jpauli.github.io/2015/03/05/opcache.html explanations.

@nervo Should I need to update [configs/opcache.prod.j2](https://github.com/manala/ansible-role-php/blob/master/templates/configs/opcache.prod.j2) too ?

